### PR TITLE
Changes to README.md file to clarify that this is a learning project - Issue #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# Family Justice C100 Service
+# Family Justice C100 Service - Copy for training purposes
 
 [![Build
 Status](https://travis-ci.org/ministryofjustice/c100-application.svg?branch=master)](https://travis-ci.org/ministryofjustice/c100-application)
+
+This is a fork of the live project, used to demonstrate and refine collaboration within the development team. All informational content should be considered fake.
 
 Work in progress: This is a Rails application to enable citizens
 to complete the C100 form. It is based on software patterns developed for the


### PR DESCRIPTION
Made changes to the README.md to clarify that this public repo is for training purposes only - issue #1:

- change title to Family Justice C100 Service - Copy for training purposes

- add as preliminary paragraph: This is a fork of the live project, used to demonstrate and refine collaboration within the development team. All informational content should be considered fake.