### PR TITLE
Removed requirement that users understand MIAM attendance requirement

### DIFF
--- a/app/forms/steps/miam/acknowledgement_form.rb
+++ b/app/forms/steps/miam/acknowledgement_form.rb
@@ -3,7 +3,7 @@ module Steps
     class AcknowledgementForm < BaseForm
       attribute :miam_acknowledgement, Boolean
 
-      validates_presence_of :miam_acknowledgement
+    #  validates_presence_of :miam_acknowledgement
 
       private
 

--- a/app/forms/steps/miam/acknowledgement_form.rb
+++ b/app/forms/steps/miam/acknowledgement_form.rb
@@ -3,8 +3,6 @@ module Steps
     class AcknowledgementForm < BaseForm
       attribute :miam_acknowledgement, Boolean
 
-    #  validates_presence_of :miam_acknowledgement
-
       private
 
       def persist!

--- a/spec/forms/steps/miam/acknowledgement_form_spec.rb
+++ b/spec/forms/steps/miam/acknowledgement_form_spec.rb
@@ -19,16 +19,18 @@ RSpec.describe Steps::Miam::AcknowledgementForm do
       end
     end
 
-    context 'validations' do
-      it { should validate_presence_of(:miam_acknowledgement) }
-    end
+#    context 'validations' do
+#      it { should validate_presence_of(:miam_acknowledgement) }
+#    end
 
-    context 'when form is valid' do
+#    context 'when form is valid' do
+    context 'when form is submitted' do
       it 'saves the record' do
-        expect(c100_application).to receive(:update).with(
-          miam_acknowledgement: true
-        ).and_return(true)
-
+#        expect(c100_application).to receive(:update).with(
+#          miam_acknowledgement: true
+#        ).and_return(true)
+        expect(c100_application).to receive(:update)
+        .and_return(true)
         expect(subject.save).to be(true)
       end
     end

--- a/spec/forms/steps/miam/acknowledgement_form_spec.rb
+++ b/spec/forms/steps/miam/acknowledgement_form_spec.rb
@@ -19,16 +19,8 @@ RSpec.describe Steps::Miam::AcknowledgementForm do
       end
     end
 
-#    context 'validations' do
-#      it { should validate_presence_of(:miam_acknowledgement) }
-#    end
-
-#    context 'when form is valid' do
     context 'when form is submitted' do
       it 'saves the record' do
-#        expect(c100_application).to receive(:update).with(
-#          miam_acknowledgement: true
-#        ).and_return(true)
         expect(c100_application).to receive(:update)
         .and_return(true)
         expect(subject.save).to be(true)


### PR DESCRIPTION
Removed the validation requirement that the form checkbox be ticked to indicate that users understand the MIAM attendance requirement as per ministerial decision:

To make the test consistent with the above change, changed the logic of the rspec test.

- fixes #11